### PR TITLE
Fix nexus integration display issues

### DIFF
--- a/NEXUS_WINDOWED_MODE_FIXES.md
+++ b/NEXUS_WINDOWED_MODE_FIXES.md
@@ -1,0 +1,73 @@
+# Nexus Integration Windowed Mode Fixes
+
+This document describes the fixes implemented to resolve issues with the Nexus integration in windowed-fullscreen and windowed modes.
+
+## Issues Fixed
+
+### 1. Windowed-Fullscreen Mode (Game Stretching)
+**Problem**: The overlay was stretching outside the screen boundaries in windowed-fullscreen mode.
+**Cause**: The code was using swapchain buffer dimensions which don't always match the actual window client area in windowed-fullscreen mode.
+**Fix**: 
+- Added proper client area detection using `GetClientRect`
+- Compare client dimensions with swapchain dimensions and use the smaller values
+- Properly scale the viewport to match the actual rendering area
+
+### 2. Windowed Mode (Black/Frozen Screen with Flickering)
+**Problem**: Black screen or frozen screen with flickering UI elements in windowed mode.
+**Cause**: 
+- Improper handling of texture size mismatches between Blish HUD and game window
+- Missing render state backups causing conflicts with game rendering
+- No proper scaling when overlay texture size differs from window size
+
+**Fixes**:
+- Added vertex buffer and constant buffer support for proper quad rendering
+- Implemented texture coordinate scaling to handle size mismatches
+- Enhanced render state backup/restore to prevent conflicts
+- Always update texture resources when addresses change
+
+## Technical Changes
+
+### 1. Enhanced OverlayState Structure
+- Added `vertex_buffer` for proper quad rendering
+- Added `constant_buffer` for shader parameters
+- Added helper structures `Vertex` and `ConstantBuffer`
+
+### 2. Improved Resize Logic
+- Now checks actual window client area dimensions
+- Handles windowed-fullscreen mode by detecting when client area is smaller than swapchain
+- Updates viewport based on actual rendering area, not just swapchain size
+
+### 3. Better Texture Management
+- Always updates textures when addresses change (not just size)
+- Proper scaling via constant buffer when texture size doesn't match window size
+- Enhanced error handling for texture creation failures
+
+### 4. Render State Management
+- More comprehensive backup of D3D11 pipeline state
+- Proper restoration of all modified states
+- Added constant buffer binding for vertex shader
+
+### 5. Shader Improvements
+- Created proper HLSL source files for shaders
+- Added support for texture coordinate scaling
+- Vertex buffer-based rendering for better control
+
+## Building
+
+To compile the shaders (requires Windows SDK with fxc.exe):
+```bash
+cd src/ui
+compile_shaders.bat
+```
+
+## Testing
+
+1. Test in fullscreen mode - should work as before
+2. Test in windowed-fullscreen mode - overlay should not stretch beyond screen
+3. Test in windowed mode - no black screen or flickering
+4. Test window resizing - overlay should adapt properly
+5. Test with different Blish HUD resolutions - proper scaling should be applied
+
+## Compatibility
+
+These changes maintain backward compatibility with the existing functionality while fixing the windowed mode issues. The overlay will automatically detect the window mode and apply appropriate rendering adjustments.

--- a/src/ui/compile_shaders.bat
+++ b/src/ui/compile_shaders.bat
@@ -1,0 +1,13 @@
+@echo off
+REM Compile HLSL shaders to CSO format
+
+echo Compiling vertex shader...
+fxc /T vs_5_0 /E main /Fo vs.cso vs.hlsl
+
+echo Compiling scaled vertex shader...
+fxc /T vs_5_0 /E main /Fo vs_scaled.cso vs_scaled.hlsl
+
+echo Compiling pixel shader...
+fxc /T ps_5_0 /E main /Fo ps.cso ps.hlsl
+
+echo Done!

--- a/src/ui/ps.hlsl
+++ b/src/ui/ps.hlsl
@@ -1,0 +1,14 @@
+// Pixel shader for Blish HUD overlay
+// Samples the overlay texture and outputs it with proper alpha blending
+
+Texture2D overlayTexture : register(t0);
+SamplerState overlaysampler : register(s0);
+
+struct PS_INPUT {
+    float4 position : SV_POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+float4 main(PS_INPUT input) : SV_TARGET {
+    return overlayTexture.Sample(overlaysampler, input.texcoord);
+}

--- a/src/ui/vs.hlsl
+++ b/src/ui/vs.hlsl
@@ -1,0 +1,19 @@
+// Vertex shader for Blish HUD overlay
+// Generates a full-screen triangle without vertex buffer
+
+struct VS_OUTPUT {
+    float4 position : SV_POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+VS_OUTPUT main(uint vertexID : SV_VertexID) {
+    VS_OUTPUT output;
+    
+    // Generate full-screen triangle coordinates
+    // This creates a triangle that covers the entire screen
+    float2 texcoord = float2((vertexID << 1) & 2, vertexID & 2);
+    output.position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+    output.texcoord = texcoord;
+    
+    return output;
+}

--- a/src/ui/vs_scaled.hlsl
+++ b/src/ui/vs_scaled.hlsl
@@ -1,0 +1,29 @@
+// Vertex shader for Blish HUD overlay with proper scaling support
+// Uses vertex buffer and constant buffer for flexible positioning
+
+cbuffer Constants : register(b0) {
+    float2 TextureScale;
+    float2 TextureOffset;
+};
+
+struct VS_INPUT {
+    float2 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+struct VS_OUTPUT {
+    float4 position : SV_POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+VS_OUTPUT main(VS_INPUT input) {
+    VS_OUTPUT output;
+    
+    // Pass through position (already in clip space)
+    output.position = float4(input.position, 0.0, 1.0);
+    
+    // Apply scaling to texture coordinates to handle size mismatches
+    output.texcoord = input.texcoord * TextureScale + TextureOffset;
+    
+    return output;
+}


### PR DESCRIPTION
Fix Nexus integration overlay display issues in windowed-fullscreen and windowed modes by correctly handling window dimensions and implementing proper texture scaling.

The overlay previously stretched in windowed-fullscreen due to using swapchain dimensions instead of the actual client area, and showed black screens or flickering in windowed mode because of unhandled texture size mismatches and render state conflicts. This PR introduces vertex/constant buffers and texture coordinate scaling to resolve these rendering discrepancies.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea83569c-5b6c-43b3-9f58-e6d3ed366c5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea83569c-5b6c-43b3-9f58-e6d3ed366c5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

