### PR TITLE
Fix nexus integration display issues

### DIFF
--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -43,8 +43,8 @@ pub fn dump_debug_data() {
         let state = OVERLAY_STATE.get().unwrap();
         let mut state_lock_opt = state.lock().unwrap();
         let state_lock = state_lock_opt.as_mut().unwrap();
-        log::info!("  Width: {}", state_lock.width);
-        log::info!("  Height: {}", state_lock.height);
+        log::info!("  BackbufferWidth: {}", state_lock.backbuffer_width);
+        log::info!("  BackbufferHeight: {}", state_lock.backbuffer_height);
         log::info!("Attempting to reset OVERLAY_STATE");
         *state_lock_opt = None;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,12 +163,8 @@ fn attach(handle: HINSTANCE) {
                     .unwrap();
             }
 
-            // Services and input/keybinds under Nexus
-            // We avoid focus grabbing inside wndproc when built with the nexus feature.
+            // Services under Nexus. Input and standalone keybinds are owned by Nexus and should not be hooked here.
             start_statistics_server();
-            init_keybinds();
-            start_mouse_input_thread();
-            initialize_controls(mainwindow_hwnd);
         }
     });
 }


### PR DESCRIPTION
Resolve Nexus integration rendering and input issues in windowed and windowed-fullscreen modes.

The previous implementation caused screen stretching due to incorrect viewport handling, flickering/black screens from constant texture re-creations, and UI conflicts from double input ownership when running in Nexus.

---
<a href="https://cursor.com/background-agent?bcId=bc-267ba34c-df80-4746-83b5-388e94f8ca49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-267ba34c-df80-4746-83b5-388e94f8ca49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

